### PR TITLE
Changes that let us run RTB3 with a PBRT docker container.

### DIFF
--- a/BatchRenderer/Mappings/ResolveMappingsValues.m
+++ b/BatchRenderer/Mappings/ResolveMappingsValues.m
@@ -103,7 +103,24 @@ for mm = 1:numel(mappings)
             map.right.value = fileInfo.resolvedPath;
             
             if ~fileInfo.isRootFolderMatch
-                disp(['Using absolute resource path: ' fileInfo.resolvedPath])
+                
+                % Copy absolute resources over to recipe folder
+                % Note: This is primarily used for docker compatibility,
+                % since the docker container needs all resource files to be
+                % in the same folder.
+                if(hints.copyResources)
+                    resources = GetWorkingFolder('resources', true, hints);
+                    copyfile(fileInfo.resolvedPath,resources);
+                    fprintf('Copied %s to %s \n',fileInfo.resolvedPath,resources);
+                    
+                    % Rename path to be written in generated PBRT file. We
+                    % specify with respect to the recipe root folder.
+                    outputLoc = fullfile('resources',hints.renderer,fileInfo.verbatimName);
+                    map.right.value = outputLoc;
+                else
+                    disp(['Using absolute resource path: ' fileInfo.resolvedPath])
+                end
+                
             end
         end
     end

--- a/Utilities/InitializeRenderToolbox.m
+++ b/Utilities/InitializeRenderToolbox.m
@@ -74,6 +74,7 @@ defaultConfig.isReuseSceneFiles = false;
 defaultConfig.isParallel = false;
 defaultConfig.isPlot = true;
 defaultConfig.isCaptureCommandResults = true;
+defaultConfig.copyResources = false;
 
 % default dynamic library path names and default values
 %   these are applied automatically, via SetRenderToolboxLibraryPath()

--- a/Utilities/SetupPBRTDocker.m
+++ b/Utilities/SetupPBRTDocker.m
@@ -1,0 +1,43 @@
+% If the user would like to run PBRT with a docker container instead of
+% local PBRT, this function should be called in the scene script. 
+% The function first pulls docker and then sets the PBRT executable to be
+% the docker run command, along with the correct input file paths. In
+% RunPBRT.m, the docker run command is called instead of local PBRT.
+%
+% Note: The hints.copyResources command must be set to true for docker to
+% run correctly, since it requires all resource files to be in the same
+% folder.
+
+function SetupPBRTDocker(hints)
+
+% Check if docker is installed
+s = system('which docker');
+
+if s
+    warning('Docker not found! \n (OSX) Are you sure you''re running MATLAB in a Docker Quickstart Terminal? ');
+else
+    
+    % Initialize the docker container (docker pull)
+    dHub = 'vistalab/pbrt';  % Docker container at dockerhub
+    fprintf('Checking for most recent docker container\n');
+    system(sprintf('docker pull %s',dHub));
+   
+    % Note:
+    % In the past we would use the command:
+    % docker run -t -i --rm -v   [directory]:/data
+    % Now instead of using the "/data" folder, we have:
+    % docker run -t -i --rm -v   [directory]:[directory]
+    % Although copying the entire folder structure into the container is
+    % redundant, it allows us to have one RunPBRT command that is compatible
+    % with both native PBRT and docker PBRT. This way, we don't have to change
+    % the names of the "output" and "sceneCopy" inputs in RunPBRT.m
+    
+    workingFolder = GetWorkingFolder('', false, hints);
+    name = sprintf('docker run -t -i --rm -v %s:%s vistalab/pbrt pbrt',workingFolder,workingFolder);
+    setpref('PBRT','executable',name);
+    
+    fprintf('\nPBRT executable set to docker container.\n\n')
+
+end
+
+end

--- a/Utilities/SetupPBRTDocker.m
+++ b/Utilities/SetupPBRTDocker.m
@@ -18,7 +18,7 @@ if s
 else
     
     % Initialize the docker container (docker pull)
-    dHub = 'vistalab/pbrt';  % Docker container at dockerhub
+    dHub = 'vistalab/pbrt-v2-spectral';  % Docker container at dockerhub
     fprintf('Checking for most recent docker container\n');
     system(sprintf('docker pull %s',dHub));
    
@@ -33,7 +33,7 @@ else
     % the names of the "output" and "sceneCopy" inputs in RunPBRT.m
     
     workingFolder = GetWorkingFolder('', false, hints);
-    name = sprintf('docker run -t -i --rm -v %s:%s vistalab/pbrt pbrt',workingFolder,workingFolder);
+    name = sprintf('docker run -t -i --rm -v %s:%s vistalab/pbrt-v2-spectral pbrt',workingFolder,workingFolder);
     setpref('PBRT','executable',name);
     
     fprintf('\nPBRT executable set to docker container.\n\n')


### PR DESCRIPTION
@benjamin-heasly  I think this is one of two ways we can potentially incorporate the PBRT docker container that Brian and I use into RTB3. Just to remind you since it's been a while, but this docker container allows users to render with PBRT without having to build it locally at all. 

The first way is more straightforward, and I've included it in this pull request. Essentially there is a new function called `SetupPBRTDocker` which one can call in the scene script. It generates the command needed to run the docker container and then replaces the PBRT executable with this new command, so that nothing needs to be changed in the `RunPBRT.m` file or anywhere else.

The main drawback to this method is that in order to switch back to local PBRT one would have to rerun the configuration script to change the PBRT executable back to the local path.

The second way which I've also implemented (but did not generate a pull request for) is to make changes in the configuration file. This is more inline with what you suggested to me last year but is more messy and complicated.

The main problem with this method is that in order to generate the docker command, we need to know the working folder of the scene. To make things even more complicated, the docker command has slightly convoluted syntax that is hard to work around. For reference, it looks something like this:
`docker run -t -i --rm -v [scene workingFolder]:[scene workingFolder] vistalab/pbrt pbrt --outfile [outfile] [input PBRT file]`

We could potentially keep things in the configuration file, but we would have to break things up. We would have to first change the PBRT executable to be `vistalab/pbrt pbrt` and pull the docker container in the configuration file. Then in the user's scene file, they would have to specify the front piece of the docker command:  `docker run -t -i --rm -v [scene workingFolder]:[scene workingFolder]` (we could potentially write a simple function that does this for them). Then in RunPBRT it would include this docker command before the PBRT executable.

The main advantage of doing it this way would be the choice of whether to use docker or not is kept in the configuration file. The downside is that it introduces several new things including this extra piece to the render command that has to be specified in the scene file if the user ran the configuration file with docker PBRT. To switch back to local PBRT, the user would still have to rerun the configuration file since the PBRT executable has to be changed.

Let me know which way you think would be better for RTB. Thanks so much.
